### PR TITLE
Support for other file browsers

### DIFF
--- a/ckeditor/widgets.py
+++ b/ckeditor/widgets.py
@@ -1,18 +1,27 @@
+import json
+
 from django import forms
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
-from django.utils.html import conditional_escape
 from django.utils.encoding import force_unicode
-from django.utils import simplejson
-
+from django.utils.functional import Promise
+from django.utils.html import conditional_escape
 from django.core.exceptions import ImproperlyConfigured
+
 from django.forms.util import flatatt
 
 import ckeditor.utils as u
 
-json_encode = simplejson.JSONEncoder().encode
+
+class LazyEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, Promise):
+            return force_unicode(obj)
+        return super(LazyEncoder, self).default(obj)
+
+json_encode = LazyEncoder().encode
 
 DEFAULT_CONFIG = {
     'skin': 'django',

--- a/ckeditor/widgets.py
+++ b/ckeditor/widgets.py
@@ -73,8 +73,8 @@ class CKEditorWidget(forms.Textarea):
         value = u.swap_in_originals(value)
 
         final_attrs = self.build_attrs(attrs, name=name)
-        self.config['filebrowserUploadUrl'] = reverse('ckeditor_upload')
-        self.config['filebrowserBrowseUrl'] = reverse('ckeditor_browse')
+        self.config.setdefault('filebrowserUploadUrl', reverse('ckeditor_upload'))
+        self.config.setdefault('filebrowserBrowseUrl', reverse('ckeditor_browse'))
         return mark_safe(render_to_string('ckeditor/widget.html', {
             'final_attrs': flatatt(final_attrs),
             'value': conditional_escape(force_unicode(value)),


### PR DESCRIPTION
Here are two commits that enable support for external filebrowsers.

The first stops `django-ckeditor` from overriding the filebrowser urls defined in CKEDITOR_CONFIG. The default is to use the built in file browser, but users can change this if they need to.

The second enabled the use of Promise objects in CKEDITOR_CONFIG. This allows users to use `reverse_lazy` in CKEDITOR_CONFIG, which comes in handy when changing the `filebrowserBrowseUrl` setting.
