### PR TITLE
Do not import from django.conf.urls.defaults

### DIFF
--- a/ckeditor/urls.py
+++ b/ckeditor/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns(
     '',

--- a/project/urls.py
+++ b/project/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import patterns, include, url
 from django.conf import settings
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 


### PR DESCRIPTION
Django 1.5 throws a deprecation warning when you do that
