### PR TITLE
Widget.render function signature has changed, but we don't care about the named parameters

### DIFF
--- a/ckeditor/widgets.py
+++ b/ckeditor/widgets.py
@@ -45,7 +45,7 @@ class CKEditorWidget(forms.Textarea):
             '%sckeditor/django/jquery_adapter.js?timestamp=%s' % (media_prefix, timestamp),
             '%sckeditor/django/widget.js?timestamp=%s' % (media_prefix, timestamp)))
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, **kwargs):
         if value is None:
             value = ''
         value = utils.swap_in_originals(value)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [egg_info]
-tag_build = +atl.7.0
+tag_build = +atl.7.1
 tag_date = false


### PR DESCRIPTION
The new Django widget rendering is typically done via a template now and the `render` is passed a `renderer` parameter that we can ignore