### PR TITLE
Use publicly accessible repo for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ckeditor/static/ckeditor/ckeditor-dev"]
 	path = ckeditor/static/ckeditor/ckeditor-dev
-	url = git@github.com:theatlantic/ckeditor-dev.git
+	url = https://github.com/theatlantic/ckeditor-dev.git


### PR DESCRIPTION
The use of an ssh git url will cause issues if we want to use github actions.