### PR TITLE
Django upgrade fixes, deletions, and additions for PY3 and Django 2.2-3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Test
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox

--- a/README.rst
+++ b/README.rst
@@ -22,8 +22,8 @@ Other::
 
     python3 -m venv venv
     . venv/bin/activate
-    python -m pip install "lxml==4.5.0" "mock==3.0.5" "Pillow==6.2.1" "Django>=2.0,<2.1"
-    python setup.py test
+    python -m pip install "lxml==4.5.0" "mock==3.0.5" "Pillow==6.2.1" "Django>=2.2,<4.0" pytest pytest-django
+    pytest
 
 
 Installation

--- a/ckeditor/__init__.py
+++ b/ckeditor/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import pkg_resources
 
 try:

--- a/ckeditor/fields.py
+++ b/ckeditor/fields.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import re
 from django.db import models
 from django import forms

--- a/ckeditor/models.py
+++ b/ckeditor/models.py
@@ -1,7 +1,6 @@
 """
 Validation logic, to be run on initialization of django models
 """
-from __future__ import absolute_import
 import os
 
 from django.conf import settings

--- a/ckeditor/settings.py
+++ b/ckeditor/settings.py
@@ -1,6 +1,5 @@
-from __future__ import absolute_import
 import copy
-import collections
+import collections.abc
 
 from django.conf import settings
 from django.urls import reverse
@@ -34,7 +33,7 @@ MEDIA_ROOT = getattr(settings, 'CKEDITOR_MEDIA_ROOT', getattr(settings, 'MEDIA_R
 
 CONFIGS = getattr(settings, 'CKEDITOR_CONFIGS', {})
 
-if isinstance(CONFIGS, collections.Mapping):
+if isinstance(CONFIGS, collections.abc.Mapping):
     CONFIGS = copy.deepcopy(CONFIGS)
     CONFIGS['default'] = dict(DEFAULT_CONFIG, **CONFIGS.pop('default', {}))
 

--- a/ckeditor/tests/test_utils.py
+++ b/ckeditor/tests/test_utils.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import os
 import mock
 from unittest import TestCase

--- a/ckeditor/tests/test_views.py
+++ b/ckeditor/tests/test_views.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import os
 import unittest
 from datetime import datetime

--- a/ckeditor/tests/test_views.py
+++ b/ckeditor/tests/test_views.py
@@ -7,7 +7,6 @@ from django.conf import settings
 
 from ckeditor import utils
 from ckeditor import settings as ck_settings
-from django.utils import six
 
 
 class ViewsTestCase(unittest.TestCase):
@@ -26,7 +25,7 @@ class ViewsTestCase(unittest.TestCase):
         ck_settings.MEDIA_ROOT = TEST_MEDIA_ROOT
 
         self.orig_settings = {}
-        for k, v in six.iteritems(self.test_settings):
+        for k, v in self.test_settings.items():
             self.orig_settings[k] = v
             setattr(ck_settings, k, v)
 
@@ -40,7 +39,7 @@ class ViewsTestCase(unittest.TestCase):
 
     def tearDown(self):
         # Reset original settings.
-        for k, v in six.iteritems(self.test_settings):
+        for k, v in self.test_settings.items():
             setattr(ck_settings, k, self.orig_settings[k])
         ck_settings.MEDIA_ROOT = ck_settings.ORIGINAL_MEDIA_ROOT
 
@@ -49,7 +48,7 @@ class ViewsTestCase(unittest.TestCase):
         # If provided prefix URL with ck_settings.UPLOAD_PREFIX.
         ck_settings.UPLOAD_PREFIX = '/media/ckuploads/'
         prefix_url = '/media/ckuploads/arbitrary/path/and/filename.ext'
-        self.failUnless(utils.get_media_url(self.test_path) == prefix_url)
+        self.assertTrue(utils.get_media_url(self.test_path) == prefix_url)
 
         # If ck_settings.UPLOAD_PREFIX is not provided, the media URL will fall
         # back to MEDIA_URL with the difference of MEDIA_ROOT and the
@@ -61,19 +60,19 @@ class ViewsTestCase(unittest.TestCase):
         # Resulting URL should never include '//' outside of schema.
         ck_settings.UPLOAD_PREFIX = 'https://test.com//media////ckuploads/'
         multi_slash_path = '//multi//////slash//path////'
-        self.failUnlessEqual(
+        self.assertEqual(
             'https://test.com/media/ckuploads/multi/slash/path/',
             utils.get_media_url(multi_slash_path))
 
     def test_get_thumb_filename(self):
         # Thumnbnail filename is the same as original
         # with _thumb inserted before the extension.
-        self.failUnless(utils.get_thumb_filename(self.test_path) == \
+        self.assertTrue(utils.get_thumb_filename(self.test_path) == \
                 self.test_path.replace('.ext', '_thumb.ext'))
         # Without an extension thumnbnail filename is the same as original
         # with _thumb appened.
         no_ext_path = self.test_path.replace('.ext', '')
-        self.failUnless(utils.get_thumb_filename(no_ext_path) == \
+        self.assertTrue(utils.get_thumb_filename(no_ext_path) == \
                 no_ext_path + '_thumb')
 
     def test_get_image_browse_urls(self):
@@ -83,27 +82,27 @@ class ViewsTestCase(unittest.TestCase):
 
         # The test_uploads path contains subfolders, we should eventually reach
         # a single dummy resource.
-        self.failUnless(utils.get_image_browse_urls())
+        self.assertTrue(utils.get_image_browse_urls())
 
         # Ignore thumbnails.
-        self.failUnless(len(utils.get_image_browse_urls()) == 1)
+        self.assertTrue(len(utils.get_image_browse_urls()) == 1)
 
         # Don't limit browse to user specific path if ck_settings.RESTRICT_BY_USER
         # is False.
         ck_settings.RESTRICT_BY_USER = False
-        self.failUnless(len(utils.get_image_browse_urls(self.mock_user)) == 1)
+        self.assertTrue(len(utils.get_image_browse_urls(self.mock_user)) == 1)
 
         # Don't limit browse to user specific path if ck_settings.RESTRICT_BY_USER
         # is True but user is a superuser.
         ck_settings.RESTRICT_BY_USER = True
         self.mock_user.is_superuser = True
-        self.failUnless(len(utils.get_image_browse_urls(self.mock_user)) == 1)
+        self.assertTrue(len(utils.get_image_browse_urls(self.mock_user)) == 1)
 
         # Limit browse to user specific path if ck_settings.RESTRICT_BY_USER is
         # True and user is not a superuser.
         ck_settings.RESTRICT_BY_USER = True
         self.mock_user.is_superuser = False
-        self.failIf(utils.get_image_browse_urls(self.mock_user))
+        self.assertFalse(utils.get_image_browse_urls(self.mock_user))
 
         ck_settings.RESTRICT_BY_USER = self.orig_settings["RESTRICT_BY_USER"]
 
@@ -115,17 +114,17 @@ class ViewsTestCase(unittest.TestCase):
         # is False.
         ck_settings.RESTRICT_BY_USER = False
         filename = utils.get_upload_filename('test.jpg', self.mock_user)
-        self.failIf(filename.replace('/%s/test.jpg' % date_path, '').\
+        self.assertFalse(filename.replace('/%s/test.jpg' % date_path, '').\
                 endswith(self.mock_user.username))
 
         # Upload to user specific path if ck_settings.RESTRICT_BY_USER is True.
         ck_settings.RESTRICT_BY_USER = True
         filename = utils.get_upload_filename('test.jpg', self.mock_user)
-        self.failUnless(filename.replace('/%s/test.jpg' % date_path, '').\
+        self.assertTrue(filename.replace('/%s/test.jpg' % date_path, '').\
                 endswith(self.mock_user.username))
 
         # Upload path should end in current date structure.
         filename = utils.get_upload_filename('test.jpg', self.mock_user)
-        self.failUnless(filename.replace('/test.jpg', '').endswith(date_path))
+        self.assertTrue(filename.replace('/test.jpg', '').endswith(date_path))
 
         ck_settings.RESTRICT_BY_USER = self.orig_settings["RESTRICT_BY_USER"]

--- a/ckeditor/urls.py
+++ b/ckeditor/urls.py
@@ -1,9 +1,8 @@
-from __future__ import absolute_import
 try:
-    from django.conf.urls import url
+    from django.urls import re_path as url
 except ImportError:
-    # Django <= 1.3
-    from django.conf.urls.defaults import url
+    # Django <= 1.11
+    from django.conf.urls import url
 
 import ckeditor.views
 

--- a/ckeditor/utils/browse.py
+++ b/ckeditor/utils/browse.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import os
 
 from ckeditor import settings as ck_settings

--- a/ckeditor/utils/common.py
+++ b/ckeditor/utils/common.py
@@ -1,9 +1,8 @@
-from __future__ import absolute_import
+import os
 import sys
 import re
 
-from django.utils import six
-from django.utils.six.moves import urllib
+import urllib
 from django.conf import settings
 
 from ckeditor import settings as ck_settings
@@ -16,7 +15,7 @@ def get_media_url(path):
     if ck_settings.UPLOAD_PREFIX:
         url = ck_settings.UPLOAD_PREFIX + path.replace(ck_settings.UPLOAD_PATH, '')
     else:
-        url = settings.MEDIA_URL + path.replace(ck_settings.MEDIA_ROOT, '')
+        url = os.path.join(settings.MEDIA_URL, path.replace(ck_settings.MEDIA_ROOT, ''))
 
     # Remove multiple forward-slashes from the path portion of the url.
     # Break url into a list.
@@ -41,7 +40,7 @@ def combine_css_classes(*classes_args):
             })
     new_classes = set([])
     for arg_pos, classes in enumerate(classes_args):
-        if isinstance(classes, six.string_types):
+        if isinstance(classes, str):
             classes = set(re_spaces.split(classes.strip()))
         else:
             try:

--- a/ckeditor/utils/config.py
+++ b/ckeditor/utils/config.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import copy
 import collections
 

--- a/ckeditor/utils/image_resize.py
+++ b/ckeditor/utils/image_resize.py
@@ -3,6 +3,7 @@ import os
 import sys
 import re
 import hashlib
+import urllib
 import logging
 
 from lxml import html
@@ -10,8 +11,6 @@ from PIL import Image, ImageFile
 
 from django.conf import settings
 from django.contrib import messages
-from django.utils import six
-from django.utils.six.moves import urllib
 
 from ckeditor import settings as ck_settings
 from .common import get_media_url
@@ -59,10 +58,10 @@ def get_dimensions(img):
     styles = img.attrib.get('style')
 
     width = match_or_none(styles, width_rx) or img.attrib.get('width')
-    if isinstance(width, six.string_types):
+    if isinstance(width, str):
         width = int(width)
     height = match_or_none(styles, height_rx) or img.attrib.get('height')
-    if isinstance(height, six.string_types):
+    if isinstance(height, str):
         height= int(height)
     return width, height
 

--- a/ckeditor/utils/image_resize.py
+++ b/ckeditor/utils/image_resize.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import os
 import sys
 import re
@@ -16,10 +15,10 @@ from ckeditor import settings as ck_settings
 from .common import get_media_url
 from functools import reduce
 
-
 ImageFile.MAXBLOCKS = 10000000
 
 logger = logging.getLogger(__name__)
+
 
 def match_or_none(string, rx):
     """

--- a/ckeditor/utils/image_upload.py
+++ b/ckeditor/utils/image_upload.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import os
 import datetime
 

--- a/ckeditor/views.py
+++ b/ckeditor/views.py
@@ -1,10 +1,8 @@
-from __future__ import absolute_import
 import django
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
 from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
-from django.utils import six
 
 from . import utils
 from . import settings as ck_settings
@@ -51,7 +49,7 @@ def browse(request):
 def configs(request):
     merged_configs = {}
     if ck_settings.CONFIGS is not None:
-        for config_name, config in six.iteritems(ck_settings.CONFIGS):
+        for config_name, config in ck_settings.CONFIGS.items():
             merged_configs[config_name] = utils.validate_config(config_name)
 
     render_kwargs = {}

--- a/ckeditor/widgets.py
+++ b/ckeditor/widgets.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from django import forms
 from django.urls import reverse
 from django.utils.safestring import mark_safe

--- a/ckeditor/widgets.py
+++ b/ckeditor/widgets.py
@@ -3,11 +3,7 @@ from django.urls import reverse
 from django.utils.safestring import mark_safe
 from django.utils.encoding import force_text
 from django.utils.html import conditional_escape
-
-try:
-    from django.forms.utils import flatatt
-except ImportError:
-    from django.forms.util import flatatt
+from django.forms.utils import flatatt
 
 from . import settings as ck_settings, utils
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,12 @@
 [egg_info]
-tag_build = +atl.7.1
+tag_build = +atl.8.0
 tag_date = false
+
+[tool:pytest]
+python_files = tests.py test_*.py *_test.py
+DJANGO_SETTINGS_MODULE = test_settings
+norecursedirs = *.egg .eggs dist build docs .tox .git __pycache__
+addopts = --tb=short --create-db
+django_find_project = false
+testpaths = ckeditor/tests
+

--- a/setup.py
+++ b/setup.py
@@ -11,14 +11,8 @@ setup(
     author_email='shaunsephton@gmail.com',
     url='http://github.com/shaunsephton/django-ckeditor',
     packages = find_packages(exclude=['project',]),
-    dependency_links = [
-        'http://dist.plone.org/thirdparty/',
-    ],
+    dependency_links = ['https://dist.plone.org/thirdparty/'],
     include_package_data=True,
-    test_suite="setuptest.setuptest.SetupTestSuite",
-    tests_require=[
-        'django-setuptest>=0.0.6',
-    ],
     classifiers=[
         "Programming Language :: Python",
         "License :: OSI Approved :: BSD License",

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,0 +1,59 @@
+import os
+
+BASE_DIR = os.path.dirname(__file__)
+
+ALLOWED_HOSTS = []
+AUTH_PASSWORD_VALIDATORS = []
+DEBUG = False
+LANGUAGE_CODE = 'en-us'
+MEDIA_URL = ''
+ROOT_URLCONF = 'test_settings'
+SECRET_KEY = 'sosupersecret'
+STATIC_URL = '/static/'
+TIME_ZONE = 'UTC'
+USE_I18N = True
+USE_L10N = True
+USE_TZ = True
+
+DATABASES = {'default': {
+    'ENGINE': 'django.db.backends.sqlite3', 
+    'NAME': os.getenv('DJANGO_DB_NAME', ':memory:') 
+}}
+
+INSTALLED_APPS = [
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.sites',
+    'django.contrib.staticfiles',
+
+    'ckeditor',
+]
+
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]
+
+
+TEMPLATES = [{
+    'BACKEND': 'django.template.backends.django.DjangoTemplates',
+    'DIRS': [],
+    'APP_DIRS': True,
+    'OPTIONS': {
+        'context_processors': [
+            'django.template.context_processors.debug',
+            'django.template.context_processors.request',
+            'django.contrib.auth.context_processors.auth',
+            'django.contrib.messages.context_processors.messages',
+        ],
+    },
+}]
+
+CKEDITOR_UPLOAD_PATH = os.path.join(BASE_DIR, 'ckeditor', 'tests', 'media')

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,20 @@
 [tox]
 skipsdist=True
 envlist = 
-    py{27,37}-dj111
-    py37-dj{20,21,22}
+    py37-dj{111,22,30,31,32}
 
 [testenv]
 usedevelop = True
 commands =
-    {envpython} setup.py test
+    pytest {posargs}
 deps = 
     lxml==4.5.0
     mock==3.0.5
     Pillow==6.2.1
+    pytest
+    pytest-django
     dj111: Django>=1.11,<2.0
-    dj20: Django>=2.0,<2.1
-    dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<3.0
+    dj30: Django>=3.0,<3.1
+    dj31: Django>=3.1,<3.2
+    dj32: Django>=3.2b1,<4.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipsdist=True
 envlist = 
-    py37-dj{111,22,30,31,32}
+    py{37,38}-dj{111,22,30,31,32}
 
 [testenv]
 usedevelop = True
@@ -18,3 +18,44 @@ deps =
     dj30: Django>=3.0,<3.1
     dj31: Django>=3.1,<3.2
     dj32: Django>=3.2b1,<4.0
+
+[testenv:pep8]
+description = Run PEP8 flake8 against the src/phatpages/ package directory
+skipsdist = true
+skip_install = true
+basepython = python3.7
+deps = flake8
+commands = flake8 ckeditor tests
+
+[testenv:clean]
+description = Clean all build and test artifacts
+skipsdist = true
+skip_install = true
+deps =
+whitelist_externals =
+    find
+    rm
+commands =
+    find {toxinidir} -type f -name "*.pyc" -delete
+    find {toxinidir} -type d -name "__pycache__" -delete
+    rm -rf {toxinidir}/django_ckeditor.egg-info {toxinidir}/htmlcov {toxinidir}/.coverage
+    rm -rf {toxinidir}/tests/db.sqlite {toxworkdir} {toxinidir}/.pytest_cache 
+
+[testenv:coverage]
+description = Run test coverage and display results
+basepython = python3.7
+deps =
+    {[testenv]deps}
+    Django>=2.2,<3.0
+    coverage
+    pytest-cov
+whitelist_externals =
+    echo
+commands =
+    pytest --cov-report html --cov-report term --cov=ckeditor
+    echo HTML coverage report: {toxinidir}/htmlcov/index.html
+
+[gh-actions]
+python =
+    3.7: py37
+    3.8: py38


### PR DESCRIPTION
Replaced the deprecated `django-setuptest` with pytest and add testing entries to the Tox matrix to handle Django 1.11, 2.2-32.

Begs the question: should we just merge the necessary code here into our Ollie monolith? The only downside I see is that _maybe, someday_ we upgrade to CKE 5, and would need to remove this app directory. 🤷🏼‍♂️ 

Yes, I'm selfishly motivated because it makes life easier for the Chief Debt Technologist.